### PR TITLE
Fixed deconstruct

### DIFF
--- a/src/twilio-routes.js
+++ b/src/twilio-routes.js
@@ -24,7 +24,7 @@ export default function(name, options) {
     });
   });
 
-  emitter.on("send-non-reply", ({data}) => {
+  emitter.on("send-non-reply", (data) => {
     if(data.communicationType === communicationType) {
       sendNonReplyMessage(data.to, data.msg, options);
     }

--- a/src/twilio-routes.js
+++ b/src/twilio-routes.js
@@ -24,9 +24,9 @@ export default function(name, options) {
     });
   });
 
-  emitter.on("send-non-reply", ({to, msg, msgCommunicationType}) => {
-    if(msgCommunicationType === communicationType) {
-      sendNonReplyMessage(to, msg, options);
+  emitter.on("send-non-reply", ({data}) => {
+    if(data.communicationType === communicationType) {
+      sendNonReplyMessage(data.to, data.msg, options);
     }
   });
 }


### PR DESCRIPTION
* The deconstruct on the event parameter expected a msgCommunicationType and not communicationType. To fix this, I just made it a normal parameter so I could reference its properties.
* This was likely copied this way from courtbot-engine. It has already been fixed over there.